### PR TITLE
fix: windows console color

### DIFF
--- a/pkg/saku/action_help.go
+++ b/pkg/saku/action_help.go
@@ -1,14 +1,12 @@
 package saku
 
 import (
-	"fmt"
-
 	"github.com/fatih/color"
 )
 
 // Shows the help message.
 func actionHelp() error {
-	fmt.Printf(`
+	colorablePrintf(`
   Usage: %s [options] <task, ...> [-- extra-options]
 
   Options:

--- a/pkg/saku/action_info.go
+++ b/pkg/saku/action_info.go
@@ -1,7 +1,6 @@
 package saku
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -9,7 +8,7 @@ import (
 )
 
 func actionInfo(tasks *TaskCollection) error {
-	fmt.Println("There are", color.MagentaString(strconv.Itoa(tasks.taskCount())), "task(s)")
+	colorablePrintln("There are", color.MagentaString(strconv.Itoa(tasks.taskCount())), "task(s)")
 
 	printTasks(tasks)
 
@@ -19,13 +18,13 @@ func actionInfo(tasks *TaskCollection) error {
 func printTasks(tasks *TaskCollection) {
 	for _, t := range tasks.tasks {
 		indent := strings.Repeat("  ", t.level)
-		fmt.Println(indent + color.CyanString("["+t.title+"]"))
+		colorablePrintln(indent + color.CyanString("["+t.title+"]"))
 		if len(t.descriptions) == 0 {
-			fmt.Println(indent + "  " + color.New(color.Italic).Sprint("No description"))
+			colorablePrintln(indent + "  " + color.New(color.Italic).Sprint("No description"))
 		}
 
 		for _, desc := range t.descriptions {
-			fmt.Println(indent + "  " + desc)
+			colorablePrintln(indent + "  " + desc)
 		}
 
 		if t.children != nil {

--- a/pkg/saku/action_version.go
+++ b/pkg/saku/action_version.go
@@ -1,9 +1,7 @@
 package saku
 
-import "fmt"
-
 func actionVersion() error {
-	fmt.Printf("saku@%s\n", Version)
+	colorablePrintf("saku@%s\n", Version)
 
 	return nil
 }

--- a/pkg/saku/logger.go
+++ b/pkg/saku/logger.go
@@ -1,7 +1,6 @@
 package saku
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/fatih/color"
@@ -13,19 +12,19 @@ type logger struct {
 
 func (l *logger) print(a ...interface{}) {
 	if l.enabled {
-		fmt.Print(a...)
+		colorablePrint(a...)
 	}
 }
 
 func (l *logger) println(a ...interface{}) {
 	if l.enabled {
-		fmt.Println(a...)
+		colorablePrintln(a...)
 	}
 }
 
 func (l *logger) printlnError(a ...interface{}) {
-	fmt.Print(color.RedString("Error:"), " ")
-	fmt.Println(a...)
+	colorablePrint(color.RedString("Error:"), " ")
+	colorablePrintln(a...)
 }
 
 // logLine logs a line of saku's phase message.

--- a/pkg/saku/util.go
+++ b/pkg/saku/util.go
@@ -1,12 +1,28 @@
 package saku
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
 
+	"github.com/mattn/go-colorable"
 	"github.com/mattn/go-isatty"
 )
+
+var colorableStdout = colorable.NewColorableStdout()
+
+func colorablePrint(a ...interface{}) (n int, err error) {
+	return fmt.Fprint(colorableStdout, a...)
+}
+
+func colorablePrintf(format string, a ...interface{}) (n int, err error) {
+	return fmt.Fprintf(colorableStdout, format, a...)
+}
+
+func colorablePrintln(a ...interface{}) (n int, err error) {
+	return fmt.Fprintln(colorableStdout, a...)
+}
 
 func emojiEnabled() bool {
 	return isatty.IsTerminal(os.Stdout.Fd())


### PR DESCRIPTION
On windows cmd.exe, color output does not work. See below capture.
(remarks, on windows terminal, everything works fine.)

![2020-11-01 01_13_03-C__Windows_System32_cmd exe](https://user-images.githubusercontent.com/1624129/97784152-c6afd080-1bdf-11eb-973b-503dc80bd05b.jpg)

To fix this behavior, use go-colorable and replace fmt.Print to fmt.Fprint function. See below capture to confirm fixed behavior.

![2020-11-01 01_14_03-C__Windows_System32_cmd exe](https://user-images.githubusercontent.com/1624129/97784174-fd85e680-1bdf-11eb-9574-1ede0697373c.jpg)
