### PR TITLE
feat: add support CRLF

### DIFF
--- a/pkg/saku/read_config.go
+++ b/pkg/saku/read_config.go
@@ -2,7 +2,6 @@ package saku
 
 import (
 	"errors"
-	"io/ioutil"
 	"path/filepath"
 	"regexp"
 
@@ -17,7 +16,7 @@ var patternEmbedDirective = regexp.MustCompile(`(?ism)<!--\s*saku\s+start\s*-->(
 func readConfig(cwd string, configFile string, l *logger) ([]byte, error) {
 	absPath := filepath.Join(cwd, configFile)
 
-	data, err := ioutil.ReadFile(absPath)
+	data, err := forceLfReadFile(absPath)
 
 	if err == nil {
 		printReading(absPath, l)
@@ -29,7 +28,7 @@ func readConfig(cwd string, configFile string, l *logger) ([]byte, error) {
 	}
 
 	absPath = filepath.Join(cwd, "README.md")
-	data, err = ioutil.ReadFile(absPath)
+	data, err = forceLfReadFile(absPath)
 
 	if err != nil {
 		return []byte{}, err

--- a/pkg/saku/util.go
+++ b/pkg/saku/util.go
@@ -1,8 +1,11 @@
 package saku
 
 import (
-	"github.com/mattn/go-isatty"
+	"io/ioutil"
 	"os"
+	"strings"
+
+	"github.com/mattn/go-isatty"
 )
 
 func emojiEnabled() bool {
@@ -21,4 +24,13 @@ func prependEmoji(e string, str string, useEmoji bool) string {
 // Returns true if the process is invoked in saku.
 func invokedInSaku() bool {
 	return os.Getenv("IN_SAKU") == "true"
+}
+
+func forceLfReadFile(filename string) ([]byte, error) {
+	content, err := ioutil.ReadFile(filename)
+	content = []byte(strings.NewReplacer(
+		"\r\n", "\n",
+		"\r", "\n",
+	).Replace(string(content)))
+	return content, err
 }


### PR DESCRIPTION
On windows, newline is usually CRLF.
So, saku.md uses CRLF has sad output. See below capture.

![2020-11-01 02_07_51](https://user-images.githubusercontent.com/1624129/97785478-9fa9cc80-1be8-11eb-9eab-8edb66843872.jpg)


Because golang does not support CRLF.
So, to support CRLF, replace CRLF to LF in saku.md.
See below capture to confirm  improved behavior.

![2020-11-01 02_08_16](https://user-images.githubusercontent.com/1624129/97785481-a33d5380-1be8-11eb-9ec2-b91aa41a36ca.jpg)
