### PR TITLE
fix: enable stdin

### DIFF
--- a/pkg/saku/exec_unix.go
+++ b/pkg/saku/exec_unix.go
@@ -12,6 +12,7 @@ import (
 func execCommand(command string) *exec.Cmd {
 	cmd := exec.Command("/bin/sh", "-c", command)
 
+	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.SysProcAttr = &syscall.SysProcAttr{}

--- a/pkg/saku/exec_windows.go
+++ b/pkg/saku/exec_windows.go
@@ -12,6 +12,7 @@ import (
 func execCommand(command string) *exec.Cmd {
 	cmd := exec.Command("cmd.exe", "/s", "/c", command)
 
+	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Env = append(os.Environ(), "IN_SAKU=true")


### PR DESCRIPTION
Currently, even if the task which wait user input like `PAUSE`, Saku does not wait user input.
See below capture. Saku ignores wait process.

![2020-11-02 09_54_04](https://user-images.githubusercontent.com/1624129/97821022-2c8d7c80-1cf4-11eb-96fc-27ae33a30176.jpg)

This pull request fixes this unexpected behavior.
See below capture. Saku waits as expected.

![2020-11-02 09_56_43](https://user-images.githubusercontent.com/1624129/97821066-5cd51b00-1cf4-11eb-9a50-7e8a63c26bfc.jpg)
